### PR TITLE
Compile netevent in one thread

### DIFF
--- a/meta-xt-cogent-fixups/conf/layer.conf
+++ b/meta-xt-cogent-fixups/conf/layer.conf
@@ -1,0 +1,14 @@
+# We have a conf and classes directory, add to BBPATH
+BBPATH .= ":${LAYERDIR}"
+
+# We have a packages directory, add to BBFILES
+BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
+            ${LAYERDIR}/recipes-*/*/*.bbappend"
+
+BBFILE_COLLECTIONS += "cogent-fixups"
+BBFILE_PATTERN_cogent-fixups := "^${LAYERDIR}/"
+BBFILE_PRIORITY_cogent-fixups = "8"
+
+# This should only be incremented on significant changes that will
+# cause compatibility issues with other layers
+LAYERSERIES_COMPAT_cogent-fixups = "dunfell"

--- a/meta-xt-cogent-fixups/recipes-support/netevent/netevent_%.bbappend
+++ b/meta-xt-cogent-fixups/recipes-support/netevent/netevent_%.bbappend
@@ -1,0 +1,3 @@
+# Sometimes we observe race during multithreaded compilation
+# so it's better to build netevent in one thread
+PARALLEL_MAKE = ""


### PR DESCRIPTION
Sometimes we observe race during multithreaded compilation
so it's better to build netevent in one thread.

This change is required only for Kingfisher with
Cogent's layer meta-rcar-gen3-adas.
