### PR TITLE
gles: don't disable fences if we are building setup with android

### DIFF
--- a/meta-xt-rcar-proprietary/recipes-graphics/gles-module/gles-common.inc
+++ b/meta-xt-rcar-proprietary/recipes-graphics/gles-module/gles-common.inc
@@ -3,7 +3,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 BRANCH = "1.11/5516664_5.1.0"
 SRCREV = "${AUTOREV}"
 EXCLUDED_APIS = "opencl vulkan"
-EXTRA_OEMAKE += "EXCLUDE_FENCE_SYNC_SUPPORT:=1"
+EXTRA_OEMAKE += "${@bb.utils.contains('XT_GUEST_INSTALL', 'doma', '', 'EXCLUDE_FENCE_SYNC_SUPPORT:=1', d)}"
 
 USE_GLES = "${@'1' if 'gsx' in '${MACHINE_FEATURES}' else '0'}"
 USE_GLES_WAYLAND = \

--- a/meta-xt-rcar-proprietary/recipes-kernel/kernel-module-gles/kernel-module-gles.inc
+++ b/meta-xt-rcar-proprietary/recipes-kernel/kernel-module-gles/kernel-module-gles.inc
@@ -31,7 +31,7 @@ PVRKM_URL = "git://git@gitpct.epam.com/epmd-aepr/pvr_km_vgpu_img.git"
 BRANCH = "1.11/5516664_5.1.0"
 SRCREV = "${AUTOREV}"
 
-EXTRA_OEMAKE += "EXCLUDE_FENCE_SYNC_SUPPORT:=1"
+EXTRA_OEMAKE += "${@bb.utils.contains('XT_GUEST_INSTALL', 'doma', '', 'EXCLUDE_FENCE_SYNC_SUPPORT:=1', d)}"
 
 # Build GFX kernel module without suffix
 KERNEL_MODULE_PACKAGE_SUFFIX = ""


### PR DESCRIPTION
Android relies on fences to sync graphics pipeline.

Signed-off-by: Volodymyr Babchuk <volodymyr_babchuk@epam.com>