### PR TITLE
Add support for the multimedia evaluation package

### DIFF
--- a/meta-xt-rcar-fixups/include/eval-pack.inc
+++ b/meta-xt-rcar-fixups/include/eval-pack.inc
@@ -1,0 +1,4 @@
+#
+# See eval-pack.bb for detailed explanations
+
+MM_EVA_L3_DIR = "${XT_MULTIMEDIA_EVA_DIR}/unpacked_L3/"

--- a/meta-xt-rcar-fixups/recipes-kernel/kernel-module-uvcs/kernel-module-uvcs-drv.bbappend
+++ b/meta-xt-rcar-fixups/recipes-kernel/kernel-module-uvcs/kernel-module-uvcs-drv.bbappend
@@ -1,0 +1,5 @@
+require include/eval-pack.inc
+
+FILESEXTRAPATHS_append := "${MM_EVA_L3_DIR}:"
+
+do_fetch[depends] = "eval-pack:do_unpack"

--- a/meta-xt-rcar-fixups/recipes-multimedia/eval-pack/eval-pack.bb
+++ b/meta-xt-rcar-fixups/recipes-multimedia/eval-pack/eval-pack.bb
@@ -1,0 +1,53 @@
+SUMMARY = "Unpack multimedia evaluation packages"
+DESCRIPTION = ""
+
+PV = "0.1"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COREBASE}/meta/COPYING.MIT;md5=3da9cfbcb788c80a0384361b4de20420"
+
+#####
+# How this recipe works
+#
+# With each BSP version manufacturer provides evaluation package
+#   for support of multimedia features like audio/video encode/decode.
+# These archives are named as `R-Car_Gen3_Series_Evaluation_Software_Package_*.zip`
+#   and considered as "level 1" in terms of this recipe.
+# "Level 1" archives contains set of "level 2" archives with separate
+#   feature specific content - like archive for MP3 decoder.
+# "Level 2" archives contains some text document and "level 3" archive,
+#   that is tar'ed sources and proprietary binaries, that are supposed
+#   to be handled by yocto.
+#
+# This recipe:
+# - looks for "level 1" archives (mask for filenames is specified in
+#   `L1_PACKAGE_MASK` variable) in `XT_MULTIMEDIA_EVA_DIR` and unpack
+#   them into ${L2_DIR} subfolder
+# - unpack `*.tar.*` files from `${L2_DIR}/*.zip` into ${MM_EVA_L3_DIR}.
+#
+# Any recipe that want to use these unpacked L3 files need to use following lines:
+#   FILESEXTRAPATHS_append := "${MM_EVA_L3_DIR}:"
+#   require include/eval-pack.inc
+#   do_fetch[depends] = "eval-pack:do_unpack"
+#####
+
+L1_PACKAGE_MASK = "R-Car_Gen3_Series_Evaluation_Software_Package_*.zip"
+
+L2_DIR = "${XT_MULTIMEDIA_EVA_DIR}/unpacked_L2/"
+# MM_EVA_L3_DIR is defined in .inc file because it need to be used in multiple places
+require include/eval-pack.inc
+
+do_unpack() {
+    if [ ! -z ${XT_MULTIMEDIA_EVA_DIR} ]; then
+        # Level 1, R-Car_Gen3_Series_Evaluation_Software_Package_*.zip, provided by manufacturer.
+        for L1_ARCHIVE in ${XT_MULTIMEDIA_EVA_DIR}/${L1_PACKAGE_MASK}
+        do
+            unzip -qo ${L1_ARCHIVE} -d ${L2_DIR}
+        done
+
+        # Level 2, intermediate archives
+        for L2_ARCHIVE in ${L2_DIR}/*.zip
+        do
+            unzip -qoj ${L2_ARCHIVE} *.tar.* -d ${MM_EVA_L3_DIR}
+        done
+    fi
+}

--- a/meta-xt-rcar-fixups/recipes-multimedia/omx-module/omx-user-module.bbappend
+++ b/meta-xt-rcar-fixups/recipes-multimedia/omx-module/omx-user-module.bbappend
@@ -1,0 +1,5 @@
+require include/eval-pack.inc
+
+FILESEXTRAPATHS_append := "${MM_EVA_L3_DIR}:"
+
+do_fetch[depends] = "eval-pack:do_unpack"


### PR DESCRIPTION
This commit has two logical parts:
  - unpacking of MM EVA packages;
  - providing a folder with prepared files for specific recipes.

The first part is implemented inside eval-pack.bb and has a detailed explanation
of its internal steps inside the recipe.

The second part is implemented by *.bbappend for affected recipes from meta-renesas.
This approach differs from implementation in copy_proprietary_softwares.sh
script provided with BSP, as we need to know neither the names of files nor
destination folders.

We made appends only for components that we use.

With an update of BSP we may need to add new bbappends.

---
This PR needs https://github.com/xen-troops/meta-xt-prod-devel-rcar/pull/11 to be merged for proper work.