### PR TITLE
kernel-module-mmngr(buf): make a pseudo to ignore the ${KERNELSRC}/in…

### DIFF
--- a/meta-xt-rcar-fixups/recipes-kernel/kernel-module-mmngr/kernel-module-mmngr.bbappend
+++ b/meta-xt-rcar-fixups/recipes-kernel/kernel-module-mmngr/kernel-module-mmngr.bbappend
@@ -1,0 +1,1 @@
+require pseudo-ignore.inc

--- a/meta-xt-rcar-fixups/recipes-kernel/kernel-module-mmngr/kernel-module-mmngrbuf.bbappend
+++ b/meta-xt-rcar-fixups/recipes-kernel/kernel-module-mmngr/kernel-module-mmngrbuf.bbappend
@@ -1,0 +1,1 @@
+require pseudo-ignore.inc

--- a/meta-xt-rcar-fixups/recipes-kernel/kernel-module-mmngr/pseudo-ignore.inc
+++ b/meta-xt-rcar-fixups/recipes-kernel/kernel-module-mmngr/pseudo-ignore.inc
@@ -1,0 +1,5 @@
+#Make a pseudo to ignore the ${KERNELSRC}/include
+#It is necessary because some of the do_install methods from different components
+#modify the directory ${KERNELSRC}/include, it bring the pseudo error and stop the build.
+
+PSEUDO_IGNORE_PATHS .= ",${KERNELSRC}/include"


### PR DESCRIPTION
…clude

It is necessary because some of the do_install methods from different components
modify the directory ${KERNELSRC}/include, it bring the pseudo error and stop the build.

Signed-off-by: Ihor Usyk <ihor_usyk@epam.com>