### PR TITLE
rcar-dom0: add support of thud

### DIFF
--- a/meta-xt-rcar-dom0/conf/layer.conf
+++ b/meta-xt-rcar-dom0/conf/layer.conf
@@ -11,5 +11,5 @@ BBFILE_PRIORITY_rcar-dom0 = "7"
 
 # This should only be incremented on significant changes that will
 # cause compatibility issues with other layers
-LAYERSERIES_COMPAT_rcar-dom0 = "dunfell"
+LAYERSERIES_COMPAT_rcar-dom0 = "thud dunfell"
 


### PR DESCRIPTION
It is required for prod-aos, because dom0 domain is based at thud
due to the lack of bsp for dunfell.

Signed-off-by: Ihor Usyk <ihor_usyk@epam.com>