### PR TITLE
[WIP] [ATF_plan_B] Add ADDITIONAL_ATFW_OPT to Renesas' and Cogent's

### DIFF
--- a/meta-xt-cogent-fixups/recipes-bsp/arm-trusted-firmware/arm-trusted-firmware_git.bbappend
+++ b/meta-xt-cogent-fixups/recipes-bsp/arm-trusted-firmware/arm-trusted-firmware_git.bbappend
@@ -1,0 +1,8 @@
+
+
+# Override the do_ipl_opt_compile from cogent's layer to add the ${ADDITIONAL_ATFW_OPT} option
+do_ipl_opt_compile () {
+    oe_runmake distclean
+    oe_runmake bl2 bl31 rcar_layout_tool rcar_srecord PLAT=${PLATFORM} SPD=opteed MBEDTLS_COMMON_MK=1 ${EXTRA_ATFW_OPT} ${ATFW_OPT_LOSSY} ${ATFW_OPT_RPC} ${ADDITIONAL_ATFW_OPT}
+}
+

--- a/meta-xt-rcar-driver-domain/recipes-bsp/arm-trusted-firmware/arm-trusted-firmware_git.bbappend
+++ b/meta-xt-rcar-driver-domain/recipes-bsp/arm-trusted-firmware/arm-trusted-firmware_git.bbappend
@@ -1,7 +1,11 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
 
 # Start cores in EL2 mode
-ATFW_OPT_append = ' RCAR_BL33_EXECUTION_EL=1'
+# Due to curent implementation of setting of build parameters,
+# we need to use ADDITIONAL_ATFW_OPT to specify execution mode.
+# Main reason is that ADDITIONAL_ATFW_OPT is used by
+# do_compile and do_ipl_opt_compile.
+ADDITIONAL_ATFW_OPT_append = ' RCAR_BL33_EXECUTION_EL=1'
 
 SRC_URI += "\
     file://0001-rcar-Use-UART-instead-of-Secure-DRAM-area-for-loggin.patch \


### PR DESCRIPTION
`ADDITIONAL_ATFW_OPT` is used by `do_compile` and `do_ipl_opt_compile`
functions, while `ATFW_OPT` is used only by `do_compile`.