### PR TITLE
domd: kingfisher: Remove linux-renesas-uapi

### DIFF
--- a/meta-xt-cogent-fixups/recipes-core/packagegroups/packagegroup-bsp.bbappend
+++ b/meta-xt-cogent-fixups/recipes-core/packagegroups/packagegroup-bsp.bbappend
@@ -1,0 +1,8 @@
+
+# In DomD do_rootfs fails on check_data_file_clashes task, because both
+# linux-libc-headers-dev and linux-renesas-uapi provide rcar-imr.h
+# Remove linux-renesas-uapi from packagegroup-bsp in meta-rcar meta-layer
+# to avoid file collision.
+RDEPENDS_packagegroup-bsp-utest_remove = " \
+    linux-renesas-uapi \
+"


### PR DESCRIPTION
This patch is based on commit from meta-xt-prod-devel:

```
e11f28b09e5cc9944d918699072130c33cdf2a72
In DomD do_rootfs fails on check_data_file_clashes task, because both
linux-libc-headers-dev and linux-renesas-uapi provide rcar-imr.h

Remove linux-renesas-uapi from packagegroup-bsp in meta-rcar meta-layer
to avoid file collision.

Signed-off-by: Valerii Chubar <valerii_chubar@epam.com>
```

Signed-off-by: Ruslan Shymkevych <ruslan_shymkevych@epam.com>