### PR TITLE
domd: mmngr: Use reserved addr from IOMEM area as MM_LOSSY_SHARED_MEM…

### DIFF
--- a/meta-xt-rcar-driver-domain/recipes-kernel/kernel-module-mmngr/files/0001-Use-first-reserved-addr-from-IOMEM-area-as-MM_LOSSY_.patch
+++ b/meta-xt-rcar-driver-domain/recipes-kernel/kernel-module-mmngr/files/0001-Use-first-reserved-addr-from-IOMEM-area-as-MM_LOSSY_.patch
@@ -1,0 +1,34 @@
+From e4926e08cb684e6f0b55458d9e298a319d84de28 Mon Sep 17 00:00:00 2001
+From: Oleksandr Tyshchenko <oleksandr_tyshchenko@epam.com>
+Date: Wed, 10 Apr 2019 19:46:38 +0300
+Subject: [PATCH 1/2] Use first reserved addr from IOMEM area as
+ MM_LOSSY_SHARED_MEM_ADDR
+
+The reason is that current addr "0x47FD7000UL" is located in domain's
+normal memory area (0x40000000 - 0xC0000000) and can't be ioremaped
+to access data.
+
+This change requires that new addr "0xE0000000UL" to be mapped to
+the current one "0x47FD7000UL" in domain config.
+
+Signed-off-by: Oleksandr Tyshchenko <oleksandr_tyshchenko@epam.com>
+---
+ mmngr_drv/mmngr/mmngr-module/files/mmngr/include/mmngr_private.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/mmngr_drv/mmngr/mmngr-module/files/mmngr/include/mmngr_private.h b/mmngr_drv/mmngr/mmngr-module/files/mmngr/include/mmngr_private.h
+index b902d47..9491c11 100644
+--- a/mmngr_drv/mmngr/mmngr-module/files/mmngr/include/mmngr_private.h
++++ b/mmngr_drv/mmngr/mmngr-module/files/mmngr/include/mmngr_private.h
+@@ -242,7 +242,7 @@ static int validate_memory_map(void);
+ #define MM_LOSSY_ADDR_MASK		(0x0003FFFFUL)  /* [17:0] */
+ #define MM_LOSSY_FMT_MASK		(0x60000000UL)  /* [30:29] */
+ #define MM_LOSSY_ENABLE_MASK		(0x80000000UL)  /* [31] */
+-#define MM_LOSSY_SHARED_MEM_ADDR	(0x47FD7000UL)
++#define MM_LOSSY_SHARED_MEM_ADDR	(0xE0000000UL)
+ #define MM_LOSSY_SHARED_MEM_SIZE	(MAX_LOSSY_ENTRIES \
+ 					* sizeof(struct LOSSY_INFO))
+ 
+-- 
+2.7.4
+

--- a/meta-xt-rcar-driver-domain/recipes-kernel/kernel-module-mmngr/kernel-module-mmngr.bbappend
+++ b/meta-xt-rcar-driver-domain/recipes-kernel/kernel-module-mmngr/kernel-module-mmngr.bbappend
@@ -1,0 +1,5 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+SRC_URI += "\
+    file://0001-Use-first-reserved-addr-from-IOMEM-area-as-MM_LOSSY_.patch \
+"


### PR DESCRIPTION
…_ADDR

This patch was taken from meta-xt-prod-devel's
0859e359dc548f576a3cc352add6880aa32eaca2

Signed-off-by: Oleksandr Tyshchenko <oleksandr_tyshchenko@epam.com>
Signed-off-by: Ruslan Shymkevych <ruslan_shymkevych@epam.com>