### PR TITLE
gles: Remove outdated recipes for kernel module

### DIFF
--- a/meta-xt-rcar-proprietary/recipes-kernel/kernel-module-gles/kernel-module-gles_1.10.bb
+++ b/meta-xt-rcar-proprietary/recipes-kernel/kernel-module-gles/kernel-module-gles_1.10.bb
@@ -1,1 +1,0 @@
-require kernel-module-gles.inc

--- a/meta-xt-rcar-proprietary/recipes-kernel/kernel-module-gles/kernel-module-gles_1.9.bb
+++ b/meta-xt-rcar-proprietary/recipes-kernel/kernel-module-gles/kernel-module-gles_1.9.bb
@@ -1,1 +1,0 @@
-require kernel-module-gles.inc


### PR DESCRIPTION
Remove recipes for kernel-module-gles 1.9 and 1.10.

Signed-off-by: Ruslan Shymkevych <ruslan_shymkevych@epam.com>