### PR TITLE
kernel-module-vspm: make a pseudo to ignore the ${KERNELSRC}/include

### DIFF
--- a/meta-xt-rcar-fixups/recipes-kernel/kernel-module-vspm/kernel-module-vspm.bbappend
+++ b/meta-xt-rcar-fixups/recipes-kernel/kernel-module-vspm/kernel-module-vspm.bbappend
@@ -1,0 +1,1 @@
+PSEUDO_IGNORE_PATHS .= ",${KERNELSRC}/include"


### PR DESCRIPTION
It is necessary because some of the do_install methods from different components
modify the directory ${KERNELSRC}/include, it bring the pseudo error and stop the build.

This commit is based on
bc4f50ed "kernel-module-mmngr(buf): make a pseudo to ignore the ${KERNELSRC}/include"