### PR TITLE
xen: Change load address and entry point to 0x88080000

### DIFF
--- a/meta-xt-rcar-driver-domain/recipes-extended/xen/xen_git.bbappend
+++ b/meta-xt-rcar-driver-domain/recipes-extended/xen/xen_git.bbappend
@@ -4,7 +4,7 @@ DEPENDS += "u-boot-mkimage-native"
 
 do_deploy_append () {
     if [ -f ${D}/boot/xen ]; then
-        uboot-mkimage -A arm64 -C none -T kernel -a 0x78080000 -e 0x78080000 -n "XEN" -d ${D}/boot/xen ${DEPLOYDIR}/xen-${MACHINE}.uImage
+        uboot-mkimage -A arm64 -C none -T kernel -a 0x88080000 -e 0x88080000 -n "XEN" -d ${D}/boot/xen ${DEPLOYDIR}/xen-${MACHINE}.uImage
         ln -sfr ${DEPLOYDIR}/xen-${MACHINE}.uImage ${DEPLOYDIR}/xen-uImage
     fi
 }


### PR DESCRIPTION
This is just fixup to already changed addresses used
for xen-chosen and for u-boot parameters.

Signed-off-by: Ruslan Shymkevych <ruslan_shymkevych@epam.com>