### PR TITLE
optee: Fix name of domain related variable

### DIFF
--- a/meta-xt-rcar-driver-domain/recipes-security/optee/optee-os_git.bb
+++ b/meta-xt-rcar-driver-domain/recipes-security/optee/optee-os_git.bb
@@ -49,7 +49,7 @@ ANDROID_EXTRA_OEMAKE = " \
 	       CFG_IN_TREE_EARLY_TAS=avb/023f8f1a-292a-432b-8fc4-de8471358067 \
 	       "
 
-EXTRA_OEMAKE += "${@bb.utils.contains('XT_DOMAINS', 'doma', '${ANDROID_EXTRA_OEMAKE}', '', d)}"
+EXTRA_OEMAKE += "${@bb.utils.contains('XT_GUEST_INSTALL', 'doma', '${ANDROID_EXTRA_OEMAKE}', '', d)}"
 
 OPTEE_ARCH_aarch64 = "arm64"
 


### PR DESCRIPTION
We use `XT_GUEST_INSTALL` to keep names of installed domains.

Signed-off-by: Ruslan Shymkevych <ruslan_shymkevych@epam.com>