### PR TITLE
[WIP] domd: atf: Deploy bootparam_sa0-4x2g.bin

### DIFF
--- a/meta-xt-rcar-driver-domain/recipes-bsp/arm-trusted-firmware/arm-trusted-firmware_git.bbappend
+++ b/meta-xt-rcar-driver-domain/recipes-bsp/arm-trusted-firmware/arm-trusted-firmware_git.bbappend
@@ -44,6 +44,9 @@ SRC_URI += "\
 
 do_deploy_append () {
     install -m 0644 ${S}/tools/renesas/rcar_layout_create/bootparam_sa0.bin ${DEPLOYDIR}/bootparam_sa0.bin
+    if [ -f ${S}/tools/renesas/rcar_layout_create/bootparam_sa0-4x2g.bin ]; then
+        install -m 0644 ${S}/tools/renesas/rcar_layout_create/bootparam_sa0-4x2g.bin ${DEPLOYDIR}/bootparam_sa0-4x2g.bin
+    fi
     install -m 0644 ${S}/tools/renesas/rcar_layout_create/cert_header_sa6.bin ${DEPLOYDIR}/cert_header_sa6.bin
     install -m 0644 ${S}/tools/renesas/rcar_layout_create/cert_header_sa6_emmc.bin ${DEPLOYDIR}/cert_header_sa6_emmc.bin
     install -m 0644 ${S}/tools/renesas/rcar_layout_create/cert_header_sa6_emmc.srec ${DEPLOYDIR}/cert_header_sa6_emmc.srec


### PR DESCRIPTION
Original recipe deploys bootparam_sa0-4x2g.srec.
At the same time for flashing through u-boot we use bin-files.

Files `bootparam_sa0-4x2g.*` and `bootparam_sa0.*` are
equal for same CPU, but it's better to keep both files for
consistency.