### PR TITLE
mata-xt-rcar-domx: remove rcar-gen3 layer dependency

### DIFF
--- a/meta-xt-rcar-domx/conf/layer.conf
+++ b/meta-xt-rcar-domx/conf/layer.conf
@@ -9,9 +9,5 @@ BBFILE_COLLECTIONS += "rcar-domx"
 BBFILE_PATTERN_rcar-domx := "^${LAYERDIR}/"
 BBFILE_PRIORITY_rcar-domx = "6"
 
-# This should only be incremented on significant changes that will
-# cause compatibility issues with other layers
-LAYERDEPENDS_rcar-domx = "rcar-gen3"
-
 LAYERSERIES_COMPAT_rcar-domx = "thud warrior zeus dunfell"
 


### PR DESCRIPTION
This layer doesn't require rcar-gen3 and this dependency should be removed.

Signed-off-by: Oleksandr Grytsov <oleksandr_grytsov@epam.com>