### PR TITLE
[Workaround] Fix issue with libc used by srec_cat

### DIFF
--- a/meta-oe-fixups/conf/layer.conf
+++ b/meta-oe-fixups/conf/layer.conf
@@ -1,0 +1,14 @@
+# We have a conf and classes directory, add to BBPATH
+BBPATH .= ":${LAYERDIR}"
+
+# We have a packages directory, add to BBFILES
+BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
+            ${LAYERDIR}/recipes-*/*/*.bbappend"
+
+BBFILE_COLLECTIONS += "oe-fixups"
+BBFILE_PATTERN_oe-fixups := "^${LAYERDIR}/"
+BBFILE_PRIORITY_oe-fixups = "8"
+
+# This should only be incremented on significant changes that will
+# cause compatibility issues with other layers
+LAYERSERIES_COMPAT_oe-fixups = "dunfell"

--- a/meta-oe-fixups/recipes-support/srecord/srecord_%.bbappend
+++ b/meta-oe-fixups/recipes-support/srecord/srecord_%.bbappend
@@ -1,0 +1,10 @@
+# srecod-native is build inside uninative environment
+# so it depends on libraries that maybe not present on
+# host during runtime.
+# For example, uninative contains libc 2.3.6, but host provides
+# only libc 2.3.1.
+# As result srec_cat is looking for functions not available on host.
+#
+# So we use rpath to use same libraries that were used for build.
+BUILD_LDFLAGS_append = " -Wl,-rpath=${STAGING_DIR}-uninative/${BUILD_ARCH}-linux/lib"
+


### PR DESCRIPTION
This commit addresses an error met during the build of u-boot - srec_cat
is linked with uninative's `libc 2.3.2+` but tries to use the host's
`libc 2.3.1` during runtime.
This results in one of two errors, depending on the linked version of glibc:
```
version `GLIBC_ABI_DT_RELR' not found
```
for `glibc 2.3.6`

or
```
_dl_call_libc_early_init: Assertion sym != NULL failed
```
for `glibc 2.3.2-2.3.5`

It's not clear at this moment, why srec_cat tries to use host's libraries
during runtime. So this commit provides a workaround - specify the path
to uninative libs as `rpath` during the build of srec_cat.

The issue was observed on Ubunto 20.04.5 starting some moment around summer.
But this is not observed if we build under Ubuntu 20.04 inside docker.
Some race conditions are expected for now.

Signed-off-by: Ruslan Shymkevych <ruslan_shymkevych@epam.com>