### PR TITLE
Set priority of layers to 10

### DIFF
--- a/meta-oe-fixups/conf/layer.conf
+++ b/meta-oe-fixups/conf/layer.conf
@@ -7,7 +7,7 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 
 BBFILE_COLLECTIONS += "oe-fixups"
 BBFILE_PATTERN_oe-fixups := "^${LAYERDIR}/"
-BBFILE_PRIORITY_oe-fixups = "8"
+BBFILE_PRIORITY_oe-fixups = "10"
 
 # This should only be incremented on significant changes that will
 # cause compatibility issues with other layers

--- a/meta-xt-cogent-fixups/conf/layer.conf
+++ b/meta-xt-cogent-fixups/conf/layer.conf
@@ -7,7 +7,7 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 
 BBFILE_COLLECTIONS += "cogent-fixups"
 BBFILE_PATTERN_cogent-fixups := "^${LAYERDIR}/"
-BBFILE_PRIORITY_cogent-fixups = "8"
+BBFILE_PRIORITY_cogent-fixups = "10"
 
 # This should only be incremented on significant changes that will
 # cause compatibility issues with other layers

--- a/meta-xt-rcar-dom0/conf/layer.conf
+++ b/meta-xt-rcar-dom0/conf/layer.conf
@@ -7,7 +7,7 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 
 BBFILE_COLLECTIONS += "rcar-dom0"
 BBFILE_PATTERN_rcar-dom0 := "^${LAYERDIR}/"
-BBFILE_PRIORITY_rcar-dom0 = "7"
+BBFILE_PRIORITY_rcar-dom0 = "10"
 
 # This should only be incremented on significant changes that will
 # cause compatibility issues with other layers

--- a/meta-xt-rcar-domu/conf/layer.conf
+++ b/meta-xt-rcar-domu/conf/layer.conf
@@ -7,7 +7,7 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 
 BBFILE_COLLECTIONS += "rcar-domu"
 BBFILE_PATTERN_rcar-domu := "^${LAYERDIR}/"
-BBFILE_PRIORITY_rcar-domu = "7"
+BBFILE_PRIORITY_rcar-domu = "10"
 
 LAYERSERIES_COMPAT_rcar-domu = "dunfell"
 

--- a/meta-xt-rcar-domx/conf/layer.conf
+++ b/meta-xt-rcar-domx/conf/layer.conf
@@ -7,7 +7,7 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 
 BBFILE_COLLECTIONS += "rcar-domx"
 BBFILE_PATTERN_rcar-domx := "^${LAYERDIR}/"
-BBFILE_PRIORITY_rcar-domx = "6"
+BBFILE_PRIORITY_rcar-domx = "10"
 
 # This should only be incremented on significant changes that will
 # cause compatibility issues with other layers

--- a/meta-xt-rcar-driver-domain/conf/layer.conf
+++ b/meta-xt-rcar-driver-domain/conf/layer.conf
@@ -7,7 +7,7 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 
 BBFILE_COLLECTIONS += "rcar-driver-domain"
 BBFILE_PATTERN_rcar-driver-domain := "^${LAYERDIR}/"
-BBFILE_PRIORITY_rcar-driver-domain = "6"
+BBFILE_PRIORITY_rcar-driver-domain = "10"
 
 # This should only be incremented on significant changes that will
 # cause compatibility issues with other layers

--- a/meta-xt-rcar-fixups/conf/layer.conf
+++ b/meta-xt-rcar-fixups/conf/layer.conf
@@ -7,7 +7,7 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 
 BBFILE_COLLECTIONS += "rcar-fixups"
 BBFILE_PATTERN_rcar-fixups := "^${LAYERDIR}/"
-BBFILE_PRIORITY_rcar-fixups = "8"
+BBFILE_PRIORITY_rcar-fixups = "10"
 
 # This should only be incremented on significant changes that will
 # cause compatibility issues with other layers

--- a/meta-xt-rcar-gles_common/conf/layer.conf
+++ b/meta-xt-rcar-gles_common/conf/layer.conf
@@ -7,6 +7,6 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 
 BBFILE_COLLECTIONS += "xt-rcar-gles_common"
 BBFILE_PATTERN_xt-rcar-gles_common = "^${LAYERDIR}/"
-BBFILE_PRIORITY_xt-rcar-gles_common = "6"
+BBFILE_PRIORITY_xt-rcar-gles_common = "10"
 
 LAYERSERIES_COMPAT_xt-rcar-gles_common = "dunfell"

--- a/meta-xt-rcar-proprietary/conf/layer.conf
+++ b/meta-xt-rcar-proprietary/conf/layer.conf
@@ -7,6 +7,6 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 
 BBFILE_COLLECTIONS += "xt-rcar-proprietary"
 BBFILE_PATTERN_xt-rcar-proprietary = "^${LAYERDIR}/"
-BBFILE_PRIORITY_xt-rcar-proprietary = "6"
+BBFILE_PRIORITY_xt-rcar-proprietary = "10"
 
 LAYERSERIES_COMPAT_xt-rcar-proprietary = "rocko sumo thud zeus dunfell"


### PR DESCRIPTION
To make sure that specific components can override/redefine settings from more generic levels, we set the following priorities for levels:

```
meta-xt-common     -  8
meta-xt-<platform> - 10
meta-xt-<product>  - 12
```

Signed-off-by: Ruslan Shymkevych <ruslan_shymkevych@epam.com>