### PR TITLE
bsp 5.9: Changes required to support DDK 1.11

### DIFF
--- a/meta-xt-rcar-fixups/recipes-graphics/gles-module/gles-user-module.bbappend
+++ b/meta-xt-rcar-fixups/recipes-graphics/gles-module/gles-user-module.bbappend
@@ -1,0 +1,4 @@
+
+FILES_${PN}_remove = " \
+    /lib/firmware/rgx.sh* \
+"

--- a/meta-xt-rcar-fixups/recipes-graphics/packagegroups/packagegroup-graphic-renesas.bbappend
+++ b/meta-xt-rcar-fixups/recipes-graphics/packagegroups/packagegroup-graphic-renesas.bbappend
@@ -1,0 +1,3 @@
+RDEPENDS_packagegroup-graphics-renesas-wayland_remove = " \
+    wayland-wsegl \
+"

--- a/meta-xt-rcar-fixups/recipes-kernel/kernel-module-gles/kernel-module-gles.bbappend
+++ b/meta-xt-rcar-fixups/recipes-kernel/kernel-module-gles/kernel-module-gles.bbappend
@@ -1,0 +1,25 @@
+LIC_FILES_CHKSUM = " \
+    file://GPL-COPYING;md5=60422928ba677faaa13d6ab5f5baaa1e \
+    file://MIT-COPYING;md5=8c2810fa6bfdc5ae5c15a0c1ade34054 \
+"
+
+SRC_URI_remove = " file://blacklist.conf"
+
+KBUILD_OUTDIR_r8a7795 = "binary_r8a7795_linux_release/target_aarch64/kbuild/"
+KBUILD_OUTDIR_r8a7796 = "binary_r8a7796_linux_release/target_aarch64/kbuild/"
+KBUILD_OUTDIR_r8a77965 = "binary_r8a77965_linux_release/target_aarch64/kbuild/"
+KBUILD_OUTDIR_r8a77990 = "binary_r8a7799_linux_release/target_aarch64/kbuild/"
+
+module_do_install() {
+    unset CFLAGS CPPFLAGS CXXFLAGS LDFLAGS
+    install -d ${D}/lib/modules/${KERNEL_VERSION}
+    cd ${KBUILD_DIR}
+    oe_runmake DISCIMAGE="${D}" install
+}
+
+FILES_${PN}_remove = " \
+    ${sysconfdir}/modprobe.d/blacklist.conf \
+"
+
+# Auto load pvrsrvkm
+KERNEL_MODULE_AUTOLOAD_append = " pvrsrvkm"


### PR DESCRIPTION
Should be merged after #37 

-----

bsp 5.9: Changes required to support DDK 1.11
These changes in fact are reverts of the few commits from
meta-renesas:
e2573c3 "rcar-gen3: wayland: separate wayland-wsegl from GLES"
03523d2 "rcar-gen3: gles-module: Update to new version"

This changes are needed in order to get DDK 1.11 working
with BSP 5.9.

Commit is "bitbake-based" implementation of the work done by
Oleksandr Tyshchenko <oleksandr_tyshchenko@epam.com>

Signed-off-by: Ruslan Shymkevych <ruslan_shymkevych@epam.com>