### PR TITLE
virtio: Disable GSX IRQ support in Xen

### DIFF
--- a/meta-xt-rcar-driver-domain/recipes-kernel/linux/files/virtio/xen-chosen.dtsi
+++ b/meta-xt-rcar-driver-domain/recipes-kernel/linux/files/virtio/xen-chosen.dtsi
@@ -11,7 +11,7 @@
 
 / {
 	chosen {
-		bootargs = "dom0_mem=256M console=dtuart dtuart=serial0 dom0_max_vcpus=4 bootscrub=0 loglvl=info hmp-unsafe=true xsm=flask console_timestamps=boot gnttab_max_frames=512";
+		bootargs = "dom0_mem=256M console=dtuart dtuart=serial0 dom0_max_vcpus=4 bootscrub=0 loglvl=info hmp-unsafe=true xsm=flask console_timestamps=boot gnttab_max_frames=512 rcar3_gsx=false";
 		xen,dom0-bootargs = "console=hvc0 ignore_loglevel";
 		/delete-property/stdout-path;
 		modules {


### PR DESCRIPTION
When the prebuilt graphics package is chosen, the GPU passthrough (native mode) is used. So we need to disable corresponding support in Xen (rcar3_gsx=false).