### PR TITLE
h3ulcb-4x2g-kf: Use gstreamer conditionally

### DIFF
--- a/meta-xt-cogent-fixups/recipes-core/packagegroups/packagegroup-bsp.bbappend
+++ b/meta-xt-cogent-fixups/recipes-core/packagegroups/packagegroup-bsp.bbappend
@@ -6,3 +6,18 @@
 RDEPENDS:packagegroup-bsp-utest:remove = " \
     linux-renesas-uapi \
 "
+
+# gstreamer related packages should be used only if we have wayland enabled
+# in the build. Otherwise (console only build) those packages need to be removed.
+RDEPENDS:packagegroup-bsp-utest:remove = " \
+    gstreamer1.0-plugins-base \
+    gstreamer1.0-plugins-base-app \
+    libgstallocators-1.0 \
+    libgstapp-1.0 \
+"
+RDEPENDS:packagegroup-bsp-utest:append = " \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'wayland', 'gstreamer1.0-plugins-base', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'wayland', 'gstreamer1.0-plugins-base-app', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'wayland', 'libgstallocators-1.0', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'wayland', 'libgstapp-1.0', '', d)} \
+"


### PR DESCRIPTION
Gstreamer-related packages should be used only if wayland is present in the build, and should be removed for consol-only builds. So, this commit wraps corresponding packages by checking the presence of the wayland.