### PR TITLE
Fix SRCREV for all components

### DIFF
--- a/meta-xt-gateway/meta-xt-domd-gen4/recipes-kernel/linux/linux-renesas_%.bbappend
+++ b/meta-xt-gateway/meta-xt-domd-gen4/recipes-kernel/linux/linux-renesas_%.bbappend
@@ -1,8 +1,8 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
 RENESAS_BSP_URL = "git://github.com/xen-troops/linux.git"
-BRANCH = "${XT_KERNEL_BRANCH}"
-SRCREV = "${XT_KERNEL_REV}"
+BRANCH = "v5.10.41/rcar-5.1.7.rc11.2-xt"
+SRCREV = "769ab722739878c3c1aaa1571f6ca996b135f8f6"
 
 SRC_URI:append = "\
     file://defconfig \

--- a/meta-xt-rcar-domu/recipes-kernel/linux-libc-headers/linux-libc-headers_5.10.bbappend
+++ b/meta-xt-rcar-domu/recipes-kernel/linux-libc-headers/linux-libc-headers_5.10.bbappend
@@ -1,5 +1,5 @@
 RENESAS_BSP_URL = "git://github.com/xen-troops/linux.git"
 
 BRANCH = "v5.10.41/rcar-5.1.4.1-xt0.2"
-SRCREV = "${AUTOREV}"
+SRCREV = "bf7d6bcdd618e5acb21118d87c76e5d8913f8dde"
 LINUX_VERSION = "5.10.41"

--- a/meta-xt-rcar-domu/recipes-kernel/linux/linux-renesas_%.bbappend
+++ b/meta-xt-rcar-domu/recipes-kernel/linux/linux-renesas_%.bbappend
@@ -3,7 +3,7 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 RENESAS_BSP_URL = "git://github.com/xen-troops/linux.git"
 
 BRANCH = "v5.10.41/rcar-5.1.4.1-xt0.2"
-SRCREV = "${AUTOREV}"
+SRCREV = "bf7d6bcdd618e5acb21118d87c76e5d8913f8dde"
 LINUX_VERSION = "5.10.41"
 
 KBUILD_DEFCONFIG_rcar = ""

--- a/meta-xt-rcar-driver-domain/recipes-kernel/linux/linux-renesas_5.10.bbappend
+++ b/meta-xt-rcar-driver-domain/recipes-kernel/linux/linux-renesas_5.10.bbappend
@@ -8,7 +8,7 @@ d)}\
 RENESAS_BSP_URL = "git://github.com/xen-troops/linux.git"
 
 BRANCH = "v5.10.41/rcar-5.1.4.1-xt0.2"
-SRCREV = "${AUTOREV}"
+SRCREV = "bf7d6bcdd618e5acb21118d87c76e5d8913f8dde"
 LINUX_VERSION = "5.10.41"
 
 SRC_URI:append = " \

--- a/meta-xt-rcar-proprietary/recipes-graphics/gles-module/gles-module-egl-headers.bb
+++ b/meta-xt-rcar-proprietary/recipes-graphics/gles-module/gles-module-egl-headers.bb
@@ -1,7 +1,10 @@
 
 PVRUM_URL ?= "git://git@gitpct.epam.com/epmd-aepr/pvr_um_vgpu_img.git"
 PVRUM_BRANCH = "${@bb.utils.contains('XT_USE_DDK1_11', '1', '1.11/5516664_5.1.0', '1.15/6052913_5.9.0', d)}"
-SRCREV = "${AUTOREV}"
+SRCREV = "${@bb.utils.contains('XT_USE_DDK1_11', '1', \
+            '4ed61e604d925bfce8ab16645f48425a581496c7', \
+            'e172e94c7d61186fe5b64db68fdef949c9ee2189', \
+            d)}"
 
 SRC_URI = " \
     ${PVRUM_URL};protocol=ssh;branch=${PVRUM_BRANCH} \

--- a/meta-xt-rcar-proprietary/recipes-graphics/gles-module/gles-um-compile.bb
+++ b/meta-xt-rcar-proprietary/recipes-graphics/gles-module/gles-um-compile.bb
@@ -7,7 +7,10 @@ PV = "${@bb.utils.contains('XT_USE_DDK1_11', '1', '1.11', '1.15', d)}"
 
 PVRUM_URL ?= "git://git@gitpct.epam.com/epmd-aepr/pvr_um_vgpu_img.git"
 PVRUM_BRANCH = "${@bb.utils.contains('XT_USE_DDK1_11', '1', '1.11/5516664_5.1.0', '1.15/6052913_5.9.0', d)}"
-SRCREV = "${AUTOREV}"
+SRCREV = "${@bb.utils.contains('XT_USE_DDK1_11', '1', \
+            '4ed61e604d925bfce8ab16645f48425a581496c7', \
+            'e172e94c7d61186fe5b64db68fdef949c9ee2189', \
+            d)}"
 
 COMPATIBLE_MACHINE = "(r8a7795|r8a7796)"
 PACKAGE_ARCH = "${MACHINE_ARCH}"

--- a/meta-xt-rcar-proprietary/recipes-kernel/kernel-module-gles/gles-km-compile.bb
+++ b/meta-xt-rcar-proprietary/recipes-kernel/kernel-module-gles/gles-km-compile.bb
@@ -12,7 +12,10 @@ S = "${WORKDIR}/git"
 
 PVRKM_URL ??= "git://git@gitpct.epam.com/epmd-aepr/pvr_km_vgpu_img.git"
 PVRKM_BRANCH ??= "${@bb.utils.contains('XT_USE_DDK1_11', '1', '1.11/5516664_5.1.0', '1.15/6052913_5.9.0', d)}"
-PVRKM_SRCREV ??= "${AUTOREV}"
+PVRKM_SRCREV ??= "${@bb.utils.contains('XT_USE_DDK1_11', '1', \
+                    '6994a4be87075975665fcef1fd95c087b0a007c8', \
+                    '487a9326d5446bf4ed2808980ab0b12d8fd3f9e9', \
+                    d)}"
 SRCREV = "${PVRKM_SRCREV}"
 
 SRC_URI = "${PVRKM_URL};protocol=ssh;branch=${PVRKM_BRANCH}"


### PR DESCRIPTION
- SRCREV is fixed for all components
- XT_KERNEL_BRANCH/XT_KERNEL_REV are removed because they should be used in the product's overrides
- SRCREV and PV are defined for the optee-test
- SRCREV selection is added for 1.11/1.15 branches of the private GSX repos