### PR TITLE
domd: prepend spaces to SRC_URI:append for weston

### DIFF
--- a/meta-xt-rcar-driver-domain/recipes-graphics/wayland/weston_%.bbappend
+++ b/meta-xt-rcar-driver-domain/recipes-graphics/wayland/weston_%.bbappend
@@ -1,6 +1,7 @@
 FILESEXTRAPATHS:append := ":${THISDIR}/${PN}"
 
-SRC_URI:append = "file://weston-seats.rules \
+SRC_URI:append = " \
+    file://weston-seats.rules \
     file://weston \
 "
 


### PR DESCRIPTION
We should always use white spaces before the filename in append. Right now append works correctly just because original SRC_URI has a chain of trailing white spaces.