### PR TITLE
[dunfell] Fix SRCREV for all components

### DIFF
--- a/meta-xt-gateway/meta-xt-domd-gen4/recipes-kernel/linux/linux-renesas_%.bbappend
+++ b/meta-xt-gateway/meta-xt-domd-gen4/recipes-kernel/linux/linux-renesas_%.bbappend
@@ -1,8 +1,8 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
 RENESAS_BSP_URL = "git://github.com/xen-troops/linux.git"
-BRANCH = "${XT_KERNEL_BRANCH}"
-SRCREV = "${XT_KERNEL_REV}"
+BRANCH = "v5.10.41/rcar-5.1.7.rc11.2-xt"
+SRCREV = "769ab722739878c3c1aaa1571f6ca996b135f8f6"
 
 SRC_URI:append = "\
     file://defconfig \

--- a/meta-xt-gateway/meta-xt-domx-gen4/recipes-bsp/optee-test/optee-test_git.bb
+++ b/meta-xt-gateway/meta-xt-domx-gen4/recipes-bsp/optee-test/optee-test_git.bb
@@ -6,9 +6,9 @@ LIC_FILES_CHKSUM = "file://${S}/LICENSE.md;md5=daa2bcccc666345ab8940aab1315a4fa"
 
 SRC_URI = "git://github.com/OP-TEE/optee_test.git"
 
-# SRCREV is not defined intentionaly, and should be defined in product's bbappend
+SRCREV = "21b347a3d75fd52fd49130e75c962c5b56123d2f"
 
-# PV should be defined in product's bbappend, eg.: "3.13.0+git${SRCPV}"
+PV = "3.13.0+git${SRCPV}"
 
 S = "${WORKDIR}/git"
 

--- a/meta-xt-rcar-domu/recipes-kernel/linux-libc-headers/linux-libc-headers_%.bbappend
+++ b/meta-xt-rcar-domu/recipes-kernel/linux-libc-headers/linux-libc-headers_%.bbappend
@@ -1,5 +1,5 @@
 RENESAS_BSP_URL = "git://github.com/xen-troops/linux.git"
 
 BRANCH = "v5.10.41/rcar-5.1.4.1-xt0.1"
-SRCREV = "${AUTOREV}"
+SRCREV = "d7c1b717e3f11b6aa0713dcefa8cf1ed4c1222af"
 LINUX_VERSION = "5.10.41"

--- a/meta-xt-rcar-domu/recipes-kernel/linux/linux-renesas_%.bbappend
+++ b/meta-xt-rcar-domu/recipes-kernel/linux/linux-renesas_%.bbappend
@@ -3,7 +3,7 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 RENESAS_BSP_URL = "git://github.com/xen-troops/linux.git"
 
 BRANCH = "v5.10.41/rcar-5.1.4.1-xt0.1"
-SRCREV = "${AUTOREV}"
+SRCREV = "d7c1b717e3f11b6aa0713dcefa8cf1ed4c1222af"
 LINUX_VERSION = "5.10.41"
 
 KBUILD_DEFCONFIG_rcar = ""

--- a/meta-xt-rcar-domx/recipes-security/optee/optee-os_git.bb
+++ b/meta-xt-rcar-domx/recipes-security/optee/optee-os_git.bb
@@ -9,7 +9,7 @@ S = "${WORKDIR}/git"
 
 SRC_URI = "git://github.com/xen-troops/optee_os.git;branch=3.9-xt-linux"
 PV = "git${SRCPV}"
-SRCREV = "${AUTOREV}"
+SRCREV = "192b616c9715604a2d2b16bc61758d160550806e"
 
 COMPATIBLE_MACHINE ?= "(salvator-x|h3ulcb|m3ulcb|m3nulcb)"
 OPTEEMACHINE = "rcar"

--- a/meta-xt-rcar-driver-domain/recipes-kernel/linux/linux-renesas_5.10.bbappend
+++ b/meta-xt-rcar-driver-domain/recipes-kernel/linux/linux-renesas_5.10.bbappend
@@ -3,7 +3,7 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 RENESAS_BSP_URL = "git://github.com/xen-troops/linux.git"
 
 BRANCH = "v5.10.41/rcar-5.1.4.1-xt0.1"
-SRCREV = "${AUTOREV}"
+SRCREV = "d7c1b717e3f11b6aa0713dcefa8cf1ed4c1222af"
 LINUX_VERSION = "5.10.41"
 
 SRC_URI:append = " \

--- a/meta-xt-rcar-proprietary/recipes-graphics/gles-module/gles-module-egl-headers.bb
+++ b/meta-xt-rcar-proprietary/recipes-graphics/gles-module/gles-module-egl-headers.bb
@@ -1,7 +1,7 @@
 
 PVRUM_URL ?= "git://git@gitpct.epam.com/epmd-aepr/pvr_um_vgpu_img.git"
 PVRUM_BRANCH = "1.11/5516664_5.1.0"
-SRCREV = "${AUTOREV}"
+SRCREV = "4ed61e604d925bfce8ab16645f48425a581496c7"
 
 SRC_URI = " \
     ${PVRUM_URL};protocol=ssh;branch=${PVRUM_BRANCH} \

--- a/meta-xt-rcar-proprietary/recipes-graphics/gles-module/gles-um-compile.bb
+++ b/meta-xt-rcar-proprietary/recipes-graphics/gles-module/gles-um-compile.bb
@@ -7,7 +7,7 @@ PV = "1.11"
 
 PVRUM_URL ?= "git://git@gitpct.epam.com/epmd-aepr/pvr_um_vgpu_img.git"
 PVRUM_BRANCH = "1.11/5516664_5.1.0"
-SRCREV = "${AUTOREV}"
+SRCREV = "4ed61e604d925bfce8ab16645f48425a581496c7"
 
 COMPATIBLE_MACHINE = "(r8a7795|r8a7796)"
 PACKAGE_ARCH = "${MACHINE_ARCH}"

--- a/meta-xt-rcar-proprietary/recipes-kernel/kernel-module-gles/gles-km-compile.bb
+++ b/meta-xt-rcar-proprietary/recipes-kernel/kernel-module-gles/gles-km-compile.bb
@@ -12,7 +12,7 @@ S = "${WORKDIR}/git"
 
 PVRKM_URL ??= "git://git@gitpct.epam.com/epmd-aepr/pvr_km_vgpu_img.git"
 PVRKM_BRANCH ??= "1.11/5516664_5.1.0"
-PVRKM_SRCREV ??= "${AUTOREV}"
+PVRKM_SRCREV ??= "6994a4be87075975665fcef1fd95c087b0a007c8"
 SRCREV = "${PVRKM_SRCREV}"
 
 SRC_URI = "${PVRKM_URL};protocol=ssh;branch=${PVRKM_BRANCH}"


### PR DESCRIPTION
- SRCREV is fixed for all components
- XT_KERNEL_BRANCH/XT_KERNEL_REV are removed because they should be used in the product's overrides
- SRCREV and PV are defined for the optee-test