### PR TITLE
domd: remove not used IMAGE_FSTYPES

### DIFF
--- a/meta-xt-rcar-driver-domain/recipes-core/images/core-image-minimal.bbappend
+++ b/meta-xt-rcar-driver-domain/recipes-core/images/core-image-minimal.bbappend
@@ -1,0 +1,3 @@
+# remove not used file types, added by
+# meta-rcar-gen3/conf/machine/include/rcar_common.inc
+IMAGE_FSTYPES:remove="wic.xz wic.bmap wic.xz.sha256sum"

--- a/meta-xt-rcar-driver-domain/recipes-graphics/images/core-image-weston.bbappend
+++ b/meta-xt-rcar-driver-domain/recipes-graphics/images/core-image-weston.bbappend
@@ -1,0 +1,3 @@
+# remove not used file types, added by
+# meta-rcar-gen3/conf/machine/include/rcar_common.inc
+IMAGE_FSTYPES:remove="wic.xz wic.bmap wic.xz.sha256sum"


### PR DESCRIPTION
We do not need "tar.bz2 wic.xz wic.bmap wic.xz.sha256sum" in the IMAGE_FSTYPES.