### PR TITLE
Remove PSEUDO_IGNORE_PATHS

### DIFF
--- a/meta-xt-rcar-fixups/recipes-kernel/kernel-module-mmngr/kernel-module-mmngr.bbappend
+++ b/meta-xt-rcar-fixups/recipes-kernel/kernel-module-mmngr/kernel-module-mmngr.bbappend
@@ -1,1 +1,0 @@
-require pseudo-ignore.inc

--- a/meta-xt-rcar-fixups/recipes-kernel/kernel-module-mmngr/kernel-module-mmngrbuf.bbappend
+++ b/meta-xt-rcar-fixups/recipes-kernel/kernel-module-mmngr/kernel-module-mmngrbuf.bbappend
@@ -1,1 +1,0 @@
-require pseudo-ignore.inc

--- a/meta-xt-rcar-fixups/recipes-kernel/kernel-module-mmngr/pseudo-ignore.inc
+++ b/meta-xt-rcar-fixups/recipes-kernel/kernel-module-mmngr/pseudo-ignore.inc
@@ -1,5 +1,0 @@
-#Make a pseudo to ignore the ${KERNELSRC}/include
-#It is necessary because some of the do_install methods from different components
-#modify the directory ${KERNELSRC}/include, it bring the pseudo error and stop the build.
-
-PSEUDO_IGNORE_PATHS .= ",${KERNELSRC}/include"

--- a/meta-xt-rcar-fixups/recipes-kernel/kernel-module-vspm/kernel-module-vspm.bbappend
+++ b/meta-xt-rcar-fixups/recipes-kernel/kernel-module-vspm/kernel-module-vspm.bbappend
@@ -1,1 +1,0 @@
-PSEUDO_IGNORE_PATHS .= ",${KERNELSRC}/include"


### PR DESCRIPTION
There is no need to use PSEUDO_IGNORE_PATHS anymore, because Renesas has fixed the issue that corrupted pseudo's database with the commit 4e767c8e0fbea287e206207e3fce047aca8122de `rcar-gen3: kernel-modules: Do not need to create "inlcude" directory` on the github.com/renesas-rcar/meta-renesas.