### PR TITLE
domu: do not use linux-libc-headers.bbappend

### DIFF
--- a/meta-xt-rcar-domu/recipes-kernel/linux-libc-headers/linux-libc-headers_5.10.bbappend
+++ b/meta-xt-rcar-domu/recipes-kernel/linux-libc-headers/linux-libc-headers_5.10.bbappend
@@ -1,5 +1,0 @@
-RENESAS_BSP_URL = "git://github.com/xen-troops/linux.git"
-
-BRANCH = "v5.10.41/rcar-5.1.4.1-xt0.2"
-SRCREV = "bf7d6bcdd618e5acb21118d87c76e5d8913f8dde"
-LINUX_VERSION = "5.10.41"


### PR DESCRIPTION
After the rework of the linux-libc-headers recipes in the meta-xt-common, we do not need to tune them in appends.